### PR TITLE
Update requirements.txt

### DIFF
--- a/memory-bot-ai/requirements.txt
+++ b/memory-bot-ai/requirements.txt
@@ -13,7 +13,7 @@ numpy
 scikit-learn
 
 # AI & LLMs
-google-generativeai=0.8.4
+google-generativeai==0.8.4
 langchain==0.3.18
 langchain-core==0.3.34
 langchain-community==0.3.17


### PR DESCRIPTION
fix: Corrected version specifier for google-generativeai

The requirements file incorrectly used a single equals sign (=) to specify the version of the google-generativeai package. This has been corrected to use the double equals sign (==), which is the correct operator for pinning package versions in pip requirements files. This ensures that the specified version (0.8.4) of the google-generativeai library is installed as intended.